### PR TITLE
feat: panic cooldown

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -22,6 +22,8 @@ config = {
         ["lsfd"] = 1
     },
 
+    -- the length, in seconds, that you want people to wait before being able to panic again
+    panicCooldown = 30,
 
     getPoliceVehicleBlip = function(vehicle)
         local class = GetVehicleClass(vehicle)

--- a/source/client.lua
+++ b/source/client.lua
@@ -647,6 +647,15 @@ RegisterNetEvent("ND_MDT:panic", function(info)
     SendNUIMessage(info)
 end)
 
+RegisterNetEvent("ND_MDT:panicOnCooldown", function(remainingTime)
+    lib.notify({
+        title = "MDT",
+        description = "Your panic button is on a cooldown for " .. remainingTime .. " more seconds",
+        type = "error",
+        duration = 5000
+    })
+end)
+
 local function getPlayerPostal()
     local postal = false
     if GetResourceState("nearest-postal") == "started" then

--- a/source/server.lua
+++ b/source/server.lua
@@ -47,7 +47,7 @@ RegisterNetEvent("ND_MDT:setUnitStatus", function(unitStatus, statusCode)
 
     if currTime - lastPanicTime < config.panicCooldown then
         local remainingTime = config.panicCooldown - (currTime - lastPanicTime)
-        TriggerClientEvent("ND_MDT:panicOnCooldown", -1, remainingTime)
+        TriggerClientEvent("ND_MDT:panicOnCooldown", source, remainingTime)
         return
     end
 

--- a/source/server.lua
+++ b/source/server.lua
@@ -47,7 +47,7 @@ RegisterNetEvent("ND_MDT:setUnitStatus", function(unitStatus, statusCode)
 
     if currTime - lastPanicTime < config.panicCooldown then
         local remainingTime = config.panicCooldown - (currTime - lastPanicTime)
-        TriggerClientEvent("ND_MDT:panicOnCooldown", source, remainingTime)
+        TriggerClientEvent("ND_MDT:panicOnCooldown", src, remainingTime)
         return
     end
 

--- a/source/server.lua
+++ b/source/server.lua
@@ -3,6 +3,7 @@ local emeregencyCalls = {}
 local activeUnits = {}
 local resourceName = cache.resource
 local chargesList = json.decode(LoadResourceFile(resourceName, "/config/charges.json"))[1]
+local lastPanicTime = 0
 require("modules.plates.server")
 
 -- retrive characters from the database based on client searches.
@@ -42,6 +43,14 @@ RegisterNetEvent("ND_MDT:setUnitStatus", function(unitStatus, statusCode)
 
     if statusCode ~= "10-99" then return end
 
+    local currTime = os.time()
+
+    if currTime - lastPanicTime < config.panicCooldown then
+        local remainingTime = config.panicCooldown - (currTime - lastPanicTime)
+        TriggerClientEvent("ND_MDT:panicOnCooldown", -1, remainingTime)
+        return
+    end
+
     local location, postal = lib.callback.await("ND_MDT:getStreet", src)
     if not location then return end
 
@@ -53,6 +62,7 @@ RegisterNetEvent("ND_MDT:setUnitStatus", function(unitStatus, statusCode)
         location = location,
         postal = postal
     })
+    lastPanicTime = currTime
 end)
 
 -- remove unit froma activeunits if they leave the server forgeting to go 10-7.


### PR DESCRIPTION
the panic button could very easily be [abused to annoy everyone](https://medal.tv/games/gta-v/clips/1Q6gjF3_8nK0wq/d1337g3dH87u?invite=cr-MSxXbkIsMzczNjk4LA) with an MDT

ive added
- a cooldown to prevent the panic sound and TTS from being spammed
- the option for people to set the cooldown to whatever they want in the config
- a client event so the player is notified of how long is left on their panic cooldown