### PR TITLE
feat: set units 10-7 on character change

### DIFF
--- a/source/server.lua
+++ b/source/server.lua
@@ -63,6 +63,13 @@ AddEventHandler("playerDropped", function()
     TriggerClientEvent("ND_MDT:updateUnitStatus", -1, activeUnits)
 end)
 
+-- Remove unit from activeUnits if they change character without going 10-7.
+AddEventHandler("ND:characterUnloaded", function(src)
+    if not activeUnits[src] then return end
+    activeUnits[src] = nil
+    TriggerClientEvent("ND_MDT:updateUnitStatus", -1, activeUnits)
+end)
+
 -- This will just send all the current calls to the client.
 lib.callback.register("ND_MDT:getUnitStatus", function(source)
     return emeregencyCalls


### PR DESCRIPTION
currently, if you are on the active unit list and you change to another character without going 10-7, your old character will remain on the active unit list

i've added an event handler for `ND:characterUnloaded` to remove the character from the active unit list, just like `playerDropped`