### PR TITLE
fix: panic being sent to all clients

### DIFF
--- a/source/client.lua
+++ b/source/client.lua
@@ -645,6 +645,8 @@ RegisterNetEvent("ND_MDT:removeReport", function(id, reportType)
 end)
 
 RegisterNetEvent("ND_MDT:panic", function(info)
+    local playerInfo = Bridge.getPlayerInfo()
+    if not Bridge.hasAccess(playerInfo.job) then return end
     SendNUIMessage(info)
 end)
 


### PR DESCRIPTION
the client panic event didn't have a job check, so when a panic button was pressed, all clients would hear the panic sound, regardless of their job

i've added the job check used in other client events to the panic event

*fixes #7*